### PR TITLE
Fix some bad rerenderings

### DIFF
--- a/buildpack-run.sh
+++ b/buildpack-run.sh
@@ -64,7 +64,7 @@ cat <<-'EOF' > $build/.profile.d/conda.sh
 EOF
 
 
-cat <<-'EOF' > ${STORAGE_LOCATION}/.condarc
+cat <<-EOF > $STORAGE_LOCN/.condarc
     channels:
       - conda-forge
       - defaults


### PR DESCRIPTION
Turns out a lack of conda-forge being on the conda channels results in some feedstocks rendering badly (e.g. qutip). It would be nice to sort that out so that everybody could rerender a feedstock on their own machine irrespective of configuration, but for now, getting the maintenance heroku bot working is more important 😄 
