### PR TITLE
Reduce conda contribution to slug size

### DIFF
--- a/buildpack-run.sh
+++ b/buildpack-run.sh
@@ -46,6 +46,7 @@ EOF
 wget -q https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
 bash miniconda.sh -b -p $HOME/.conda
 $HOME/.conda/bin/conda install -c conda-forge --yes conda-execute conda-smithy python=3
+$HOME/.conda/bin/conda clean -tipsy
 
 # Patch conda-smithy to use https not ssh (We don't have ssh keys on heroku)
 sed -i 's/repo.ssh_url/repo.clone_url/g' $HOME/.conda/lib/python3.5/site-packages/conda_smithy/feedstocks.py


### PR DESCRIPTION
Clean up any `conda` download remnants that are unneeded. Doing this as the slug size seems to be surpassing the Heroku maximum slug size of 300MB by just a hair ( ~1.3MB ).

If this trend continues (likely due to downloading all of the feedstocks), we may need to rethink that strategy as well. Until then this should give us some more buffer room.

xref: https://devcenter.heroku.com/articles/slug-compiler#slug-size

cc @pelson