### PR TITLE
Temporarily pin `conda` to `4.1.x`

### DIFF
--- a/buildpack-run.sh
+++ b/buildpack-run.sh
@@ -45,7 +45,7 @@ EOF
 
 wget -q https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
 bash miniconda.sh -b -p $HOME/.conda
-$HOME/.conda/bin/conda install -c conda-forge --yes conda-execute conda-smithy python=3
+$HOME/.conda/bin/conda install -c conda-forge --yes conda=4.1 conda-execute conda-smithy python=3
 $HOME/.conda/bin/conda clean -tipsy
 
 # Patch conda-smithy to use https not ssh (We don't have ssh keys on heroku)


### PR DESCRIPTION
Temporarily pin `conda` to `4.1.x` so that `conda-smithy` works.

Working on a fix in PR ( https://github.com/conda-forge/conda-smithy/pull/394 ). Can revert after we have a patch release with a fix.