### PR TITLE
Drop renaming remotes

### DIFF
--- a/buildpack-run.sh
+++ b/buildpack-run.sh
@@ -91,8 +91,5 @@ echo $GH_TOKEN > ~/.conda-smithy/github.token
 mkdir -p $STORAGE_LOCN/feedstocks
 $HOME/.conda/bin/feedstocks clone --feedstocks-dir $STORAGE_LOCN/feedstocks
 
-# Rename origin -> upstream universally.
-$HOME/.conda/bin/feedstocks apply-cloned --feedstocks-directory $STORAGE_LOCN/feedstocks git remote rename origin upstream
-
 # -------
 


### PR DESCRIPTION
Seems that the latest `conda-smithy` (2.1.0) is correctly making all remotes upstream. As such, we no longer need a step. So go ahead and drop it. Otherwise we encounter an error as we try to handle this twice.

Note: This was likely fixed by PR ( https://github.com/conda-forge/conda-smithy/pull/458 ).