### PR TITLE
Use conda-forge's git

### DIFF
--- a/buildpack-run.sh
+++ b/buildpack-run.sh
@@ -45,7 +45,7 @@ EOF
 
 wget -q https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
 bash miniconda.sh -b -p "${HOME}/.conda"
-"${HOME}/.conda/bin/conda" install -c conda-forge --yes conda-execute conda-smithy python=3
+"${HOME}/.conda/bin/conda" install -c conda-forge --yes git conda-execute conda-smithy python=3
 "${HOME}/.conda/bin/conda" clean -tipsy
 
 # Patch conda-smithy to use https not ssh (We don't have ssh keys on heroku)


### PR DESCRIPTION
Seems that we are running into issues cloning a repo into a directory on Heroku. This seems like a rather basic thing to do with `git`. So it may just be that Heroku has a really old copy of `git`. This adds `git` from `conda-forge` so that a recent enough version can be used and this issue resolved.