### PR TITLE
Switch to Miniconda 4.2.12 with Python 3.5

### DIFF
--- a/buildpack-run.sh
+++ b/buildpack-run.sh
@@ -43,7 +43,7 @@ EOF
 
 # ----------
 
-wget -q https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
+wget -q https://repo.continuum.io/miniconda/Miniconda3-4.2.12-Linux-x86_64.sh -O miniconda.sh
 bash miniconda.sh -b -p "${HOME}/.conda"
 "${HOME}/.conda/bin/conda" install -c conda-forge --yes git conda-execute conda-smithy python=3
 "${HOME}/.conda/bin/conda" clean -tipsy


### PR DESCRIPTION
As it appears some dependencies are not correctly satisfied on Python 3.6 and they are causing us some issues with getting proper re-renderings, simply switch to the latest Miniconda using Python 3.5. At least on Python 3.5, we are confident that we have all the dependencies needed to do proper re-renderings. We can always revert this pinning once the underlying issues are fixed.