### PR TITLE
Force Python 3.5

### DIFF
--- a/buildpack-run.sh
+++ b/buildpack-run.sh
@@ -45,7 +45,7 @@ EOF
 
 wget -q https://repo.continuum.io/miniconda/Miniconda3-4.2.12-Linux-x86_64.sh -O miniconda.sh
 bash miniconda.sh -b -p "${HOME}/.conda"
-"${HOME}/.conda/bin/conda" install -c conda-forge --yes git conda-execute conda-smithy python=3
+"${HOME}/.conda/bin/conda" install -c conda-forge --yes git conda-execute conda-smithy python=3.5
 "${HOME}/.conda/bin/conda" clean -tipsy
 
 # Patch conda-smithy to use https not ssh (We don't have ssh keys on heroku)


### PR DESCRIPTION
Follow-up to PR ( https://github.com/conda-forge/conda-forge-maintenance/pull/35 ).

As it appears some dependencies are not correctly satisfied on Python 3.6 and they are causing us some issues with getting proper re-renderings and it appears setting the Miniconda version was not sufficient to force the Python version, simply pin the Python during upgrade to 3.5. At least on Python 3.5, we are confident that we have all the dependencies needed to do proper re-renderings. We can always revert this pinning once the underlying issues are fixed.